### PR TITLE
ref!: Skip by default overwriting duplicates

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,11 +91,12 @@ Usage:
 
 Flags:
   -d, --depth-recursive int   Regulates how many levels the recursive dependencies would be cloned. (default -1)
+  -f, --force                 Force overwriting existing repositories
   -h, --help                  help for import
   -i, --input .repos          Path to input .repos file
   -r, --recursive .repos      Recursively search of other .repos file in the cloned repositories
+  -n, --retry int             Number of attempts to import repositories (default 2)
   -l, --shallow               Clone repositories with a depth of 1
-  -s, --skip                  Skip existing repositories
   -w, --workers int           Number of concurrent workers to use (default 8)
 ```
 
@@ -138,14 +139,14 @@ Afterwards, you should be able to do `rv <TAB>` to get autocompletion for the av
 
 I ran a quick comparison between `rv` and `vcs` using the [valid_example.repos](./test/valid_example.repos) file for different commands using `8` workers.
 
-|    Command    |   vcs   |   rv    |
-| :-----------: | :-----: | :-----: |
-|    import     | 2.363 s | 1.753 s |
-| import + skip | 0.691 s | 0.004 s |
-|      log      | 0.248 s | 0.021 s |
-|     pull      | 0.635 s | 0.417 s |
-|    status     | 0.238 s | 0.035 s |
-|   validate    | 0.869 s | 0.414 s |
+|      Command       |   vcs   |   rv    |
+| :----------------: | :-----: | :-----: |
+| import (overwrite) | 2.363 s | 1.753 s |
+|   import + skip    | 0.691 s | 0.004 s |
+|        log         | 0.248 s | 0.021 s |
+|        pull        | 0.635 s | 0.417 s |
+|       status       | 0.238 s | 0.035 s |
+|      validate      | 0.869 s | 0.414 s |
 
 ## Future enhancements
 

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -33,20 +33,20 @@ import cycle.`,
 		filePath, _ := cmd.Flags().GetString("input")
 		recursiveFlag, _ := cmd.Flags().GetBool("recursive")
 		numRetries, _ := cmd.Flags().GetInt("retry")
-		skipExisting, _ := cmd.Flags().GetBool("skip")
+		overwriteExisting, _ := cmd.Flags().GetBool("force")
 		shallowClone, _ := cmd.Flags().GetBool("shallowClone")
 		depthRecursive, _ := cmd.Flags().GetInt("depth-recursive")
 		numWorkers, _ := cmd.Flags().GetInt("workers")
 
 		// Import repository files in the given file
-		validFile := singleCloneSweep(cloningPath, filePath, numWorkers, skipExisting, shallowClone, numRetries)
+		validFile := singleCloneSweep(cloningPath, filePath, numWorkers, overwriteExisting, shallowClone, numRetries)
 		if !validFile {
 			os.Exit(1)
 		}
 		if !recursiveFlag {
 			os.Exit(0)
 		}
-		nestedImportClones(cloningPath, filePath, depthRecursive, numWorkers, skipExisting, shallowClone, numRetries)
+		nestedImportClones(cloningPath, filePath, depthRecursive, numWorkers, overwriteExisting, shallowClone, numRetries)
 
 	},
 }
@@ -58,12 +58,12 @@ func init() {
 	importCmd.Flags().StringP("input", "i", "", "Path to input `.repos` file")
 	importCmd.Flags().BoolP("recursive", "r", false, "Recursively search of other `.repos` file in the cloned repositories")
 	importCmd.Flags().IntP("retry", "n", 2, "Number of attempts to import repositories")
-	importCmd.Flags().BoolP("skip", "s", false, "Skip existing repositories")
+	importCmd.Flags().BoolP("force", "f", false, "Force overwriting existing repositories")
 	importCmd.Flags().BoolP("shallow", "l", false, "Clone repositories with a depth of 1")
 	importCmd.Flags().IntP("workers", "w", 8, "Number of concurrent workers to use")
 }
 
-func singleCloneSweep(root string, filePath string, numWorkers int, skipExisting bool, shallowClone bool, numRetries int) bool {
+func singleCloneSweep(root string, filePath string, numWorkers int, overwriteExisting bool, shallowClone bool, numRetries int) bool {
 	utils.PrintSection(fmt.Sprintf("Importing from %s", filePath))
 	utils.PrintSeparator()
 	config, err := utils.ParseReposFile(filePath)
@@ -88,7 +88,7 @@ func singleCloneSweep(root string, filePath string, numWorkers int, skipExisting
 				} else {
 					success := false
 					for i := 0; i < numRetries; i++ {
-						success = utils.PrintGitClone(job.Repo.URL, job.Repo.Version, job.DirName, skipExisting, shallowClone, false)
+						success = utils.PrintGitClone(job.Repo.URL, job.Repo.Version, job.DirName, overwriteExisting, shallowClone, false)
 						if success {
 							break
 						}
@@ -121,7 +121,7 @@ func singleCloneSweep(root string, filePath string, numWorkers int, skipExisting
 	return validFile
 }
 
-func nestedImportClones(cloningPath string, initialFilePath string, depthRecursive int, numWorkers int, skipExisting bool, shallowClone bool, numRetries int) {
+func nestedImportClones(cloningPath string, initialFilePath string, depthRecursive int, numWorkers int, overwriteExisting bool, shallowClone bool, numRetries int) {
 	// Recursively import .repos files found
 	clonedReposFiles := map[string]bool{initialFilePath: true}
 	validFiles := true
@@ -143,7 +143,7 @@ func nestedImportClones(cloningPath string, initialFilePath string, depthRecursi
 		newReposFileFound := false
 		for _, filePathToClone := range foundReposFiles {
 			if _, ok := clonedReposFiles[filePathToClone]; !ok {
-				validFiles = singleCloneSweep(cloningPath, filePathToClone, numWorkers, skipExisting, shallowClone, numRetries)
+				validFiles = singleCloneSweep(cloningPath, filePathToClone, numWorkers, overwriteExisting, shallowClone, numRetries)
 				clonedReposFiles[filePathToClone] = true
 				newReposFileFound = true
 				if !validFiles {

--- a/test/git_helpers_test.go
+++ b/test/git_helpers_test.go
@@ -110,7 +110,8 @@ func TestCheckGitUrl(t *testing.T) {
 }
 
 func TestCloneGitRepo(t *testing.T) {
-	if utils.GitClone("https://github.com/ros2/demos.git", "rolling", "/tmp/testdata/demos", false, false, false) != utils.SuccessfullClone {
+	repoPath := "/tmp/testdata/demos_clone"
+	if utils.GitClone("https://github.com/ros2/demos.git", "rolling", repoPath, false, false, false) != utils.SuccessfullClone {
 		t.Errorf("Expected to successfully clone git repository")
 	}
 	if utils.GitClone("https://github.com/ros2/ros2cli", "", "/tmp/testdata/ros2cli", false, false, false) != utils.SuccessfullClone {
@@ -119,10 +120,13 @@ func TestCloneGitRepo(t *testing.T) {
 	if utils.GitClone("https://github.com/ros2/sadasdasd.git", "", "/tmp/testdata/sdasda", false, false, false) != utils.FailedClone {
 		t.Errorf("Expected to fail to clone git repository")
 	}
-	if utils.GitClone("https://github.com/ros2/demos.git", "", "/tmp/testdata/demos", true, false, false) != utils.SkippedClone {
+	if utils.GitClone("https://github.com/ros2/demos.git", "", repoPath, false, false, false) != utils.SkippedClone {
 		t.Errorf("Expected to skip to clone git repository")
 	}
-	if utils.GitClone("https://github.com/ros2/demos.git", "", "/tmp/testdata/demos", false, true, false) != utils.SuccessfullClone {
+	if utils.GitClone("https://github.com/ros2/demos.git", "", repoPath, true, false, false) != utils.SuccessfullClone {
+		t.Errorf("Expected to overwrite found git repository")
+	}
+	if utils.GitClone("https://github.com/ros2/demos.git", "", "/tmp/testdata/demos", true, true, false) != utils.SuccessfullClone {
 		t.Errorf("Expected to successfully to clone git repository with shallow enabled")
 	}
 	count, err := utils.RunGitCmd("/tmp/testdata/demos", "rev-list", nil, []string{"--all", "--count"}...)

--- a/utils/git_helpers.go
+++ b/utils/git_helpers.go
@@ -162,11 +162,11 @@ func GitSwitch(path string, branch string, createBranch bool, detachHead bool) (
 }
 
 // GitClone Clone a given repository URL
-func GitClone(url string, version string, clonePath string, skipIfExisting bool, shallowClone bool, enablePrompt bool) int {
+func GitClone(url string, version string, clonePath string, overwriteExisting bool, shallowClone bool, enablePrompt bool) int {
 
 	// Check if clonePath exists
 	if _, err := os.Stat(clonePath); err == nil {
-		if skipIfExisting {
+		if !overwriteExisting {
 			return SkippedClone
 		} else {
 			// Remove existing clonePath
@@ -254,10 +254,10 @@ func PrintCheckGit(path string, url string, version string, enablePrompt bool) b
 }
 
 // PrintGitClone Pretty print git clone
-func PrintGitClone(url string, version string, path string, skipIfExisting bool, shallowClone bool, enablePrompt bool) bool {
+func PrintGitClone(url string, version string, path string, overwriteExisting bool, shallowClone bool, enablePrompt bool) bool {
 	var cloneMsg string
 	var cloneSuccessful bool
-	statusClone := GitClone(url, version, path, skipIfExisting, shallowClone, enablePrompt)
+	statusClone := GitClone(url, version, path, overwriteExisting, shallowClone, enablePrompt)
 	switch statusClone {
 	case SuccessfullClone:
 		cloneMsg = fmt.Sprintf("Successfully cloned git repository '%s' with version '%s'\n", url, version)


### PR DESCRIPTION
The previous behavior for the import cmd was to overwrite any existing repository. As it was explained in #9, this can be quite destructive as it deletes the duplicated directory removing any local changes the user my want to keep.

To provide some form of safe-rails for those users that do not expect such behavior, I replaced the `--skip` flag for a `--force` and to indicate that those repositories that are duplicated should be overwritten.