### PR TITLE
Add export command

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Usage:
 
 Available Commands:
   completion  Generate the autocompletion script for the specified shell
+  export      Export list of available repositories
   help        Help about any command
   import      Import repositories listed in the given .repos file
   log         Get logs of all repositories.

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -1,0 +1,67 @@
+/*
+Copyright © 2024 Erick Kramer <erickkramer@gmail.com>
+*/
+package cmd
+
+import (
+	"ripvcs/utils"
+
+	"github.com/spf13/cobra"
+)
+
+// statusCmd represents the status command
+var exportCmd = &cobra.Command{
+	Use:   "export <optional path>",
+	Short: "Export list of available repositories",
+	Long: `Export list of available repositories..
+
+If no path is given, it checks the finds any Git repository relative to the current path.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		var root string
+		if len(args) == 0 {
+			root = "."
+		} else {
+			root = args[0]
+		}
+		gitRepos := utils.FindGitRepositories(root)
+
+		filePath, _ := cmd.Flags().GetString("output")
+		numWorkers, _ := cmd.Flags().GetInt("workers")
+		getCommitsFlag, _ := cmd.Flags().GetBool("commits")
+		getTagsFlags, _ := cmd.Flags().GetBool("tags")
+
+		// Create a channel to send work to the workers with a buffer size of length gitRepos
+		jobs := make(chan string, len(gitRepos))
+
+		// Create a channel to indicate when the go routines have finished
+		done := make(chan bool)
+
+		// Iterate over the numWorkers
+		for i := 0; i < numWorkers; i++ {
+			go func() {
+				for repo := range jobs {
+					utils.PrintGitStatus(repo, skipEmtpy, plainStatus)
+				}
+				done <- true
+			}()
+		}
+		// Send each git repository path to the jobs channel
+		for _, repo := range gitRepos {
+			jobs <- repo
+		}
+		close(jobs) // Close channel to signal no more work will be sent
+
+		// wait for all goroutines to finish
+		for i := 0; i < numWorkers; i++ {
+			<-done
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(exportCmd)
+	exportCmd.Flags().IntP("workers", "w", 8, "Number of concurrent workers to use")
+	exportCmd.Flags().StringP("output", "o", "", "Path to output `.repos` file")
+	exportCmd.Flags().BoolP("commits", "c", false, "Export repositories hashes instead of branches")
+	exportCmd.Flags().BoolP("tags", "t", false, "Export repositories tags instead of branches.")
+}

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -82,13 +82,13 @@ func singleCloneSweep(root string, filePath string, numWorkers int, overwriteExi
 		go func() {
 			for job := range jobs {
 				if job.Repo.Type != "git" {
-					utils.PrintRepoEntry(job.DirName, "")
+					utils.PrintRepoEntry(job.RepoPath, "")
 					utils.PrintErrorMsg("Unsupported repository type.\n")
 					results <- false
 				} else {
 					success := false
 					for i := 0; i < numRetries; i++ {
-						success = utils.PrintGitClone(job.Repo.URL, job.Repo.Version, job.DirName, overwriteExisting, shallowClone, false)
+						success = utils.PrintGitClone(job.Repo.URL, job.Repo.Version, job.RepoPath, overwriteExisting, shallowClone, false)
 						if success {
 							break
 						}
@@ -101,7 +101,7 @@ func singleCloneSweep(root string, filePath string, numWorkers int, overwriteExi
 	}
 
 	for dirName, repo := range config.Repositories {
-		jobs <- utils.RepositoryJob{DirName: filepath.Join(root, dirName), Repo: repo}
+		jobs <- utils.RepositoryJob{RepoPath: filepath.Join(root, dirName), Repo: repo}
 	}
 	close(jobs)
 	// wait for all goroutines to finish

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -45,11 +45,11 @@ and that the provided version exist.`,
 			go func() {
 				for job := range jobs {
 					if job.Repo.Type != "git" {
-						utils.PrintRepoEntry(job.DirName, "")
+						utils.PrintRepoEntry(job.RepoPath, "")
 						utils.PrintErrorMsg("Unsupported repository type.\n")
 						results <- false
 					} else {
-						success := utils.PrintCheckGit(job.DirName, job.Repo.URL, job.Repo.Version, false)
+						success := utils.PrintCheckGit(job.RepoPath, job.Repo.URL, job.Repo.Version, false)
 						results <- success
 					}
 				}
@@ -58,7 +58,7 @@ and that the provided version exist.`,
 		}
 
 		for key, repo := range config.Repositories {
-			jobs <- utils.RepositoryJob{DirName: key, Repo: repo}
+			jobs <- utils.RepositoryJob{RepoPath: key, Repo: repo}
 		}
 		close(jobs)
 		// wait for all goroutines to finish

--- a/test/git_helpers_test.go
+++ b/test/git_helpers_test.go
@@ -84,23 +84,45 @@ func TestGetGitBranch(t *testing.T) {
 	if utils.GetGitBranch("/tmp/testdata/valid_repo") != "main" {
 		t.Errorf("Failed to get main branch for valid git repository")
 	}
+	testingTag := "0.34.0"
+	repoPath := "/tmp/testdata/demos_branch"
+	if utils.GitClone("https://github.com/ros2/demos.git", testingTag, repoPath, false, false, false) != utils.SuccessfullClone {
+		t.Errorf("Expected to successfully clone git repository")
+	}
+	obtainedTag := utils.GetGitBranch(repoPath)
+	if obtainedTag != testingTag {
+		t.Errorf("Failed to get tag for the cloned repository. Got %s", obtainedTag)
+	}
 }
 
 func TestGetGitCommitSha(t *testing.T) {
 	testingSha := "839b622bc40ec62307d6ba0615adb9b8bd1cbc30"
-	if utils.GitClone("https://github.com/ros2/demos.git", testingSha, "/tmp/testdata/demos", false, false, false) != utils.SuccessfullClone {
+	repoPath := "/tmp/testdata/demos_sha"
+	if utils.GitClone("https://github.com/ros2/demos.git", testingSha, repoPath, false, false, false) != utils.SuccessfullClone {
 		t.Errorf("Expected to successfully clone git repository")
 	}
-	if utils.GetGitCommitSha("/tmp/testdata/demos") != testingSha {
-		t.Errorf("Failed to pull valid repository.")
+	if utils.GetGitCommitSha(repoPath) != testingSha {
+		t.Errorf("Failed to get commit sha of the cloned git repository")
+	}
+}
+
+func TestGetGitRemoteURL(t *testing.T) {
+	repoPath := "/tmp/testdata/demos_url"
+	remoteUrl := "https://github.com/ros2/demos.git"
+	if utils.GitClone(remoteUrl, "", repoPath, false, false, false) != utils.SuccessfullClone {
+		t.Errorf("Expected to successfully clone git repository")
+	}
+	if utils.GetGitRemoteURL(repoPath) != remoteUrl {
+		t.Errorf("Failed to get remote URL for the git repository")
 	}
 }
 
 func TestGitPull(t *testing.T) {
-	if utils.GitClone("https://github.com/ros2/demos.git", "rolling", "/tmp/testdata/demos", false, false, false) != utils.SuccessfullClone {
+	repoPath := "/tmp/testdata/demos_pull"
+	if utils.GitClone("https://github.com/ros2/demos.git", "rolling", repoPath, false, false, false) != utils.SuccessfullClone {
 		t.Errorf("Expected to successfully clone git repository")
 	}
-	msg := utils.PullGitRepo("/tmp/testdata/demos")
+	msg := utils.PullGitRepo(repoPath)
 	if strings.TrimSpace(msg) != "Already up to date." {
 		t.Errorf("Failed to pull valid repository. Obtained %s", msg)
 	}
@@ -149,20 +171,6 @@ func TestIsValidCommitSha(t *testing.T) {
 func TestCloneGitRepo(t *testing.T) {
 	repoPath := "/tmp/testdata/demos_clone"
 	if utils.GitClone("https://github.com/ros2/demos.git", "rolling", repoPath, false, false, false) != utils.SuccessfullClone {
-	testingSha := "839b622bc40ec62307d6ba0615adb9b8bd1cbc30"
-	if utils.GitClone("https://github.com/ros2/demos.git", testingSha, "/tmp/testdata/demos", false, false, false) != utils.SuccessfullClone {
-		t.Errorf("Expected to successfully clone git repository given a SHA")
-	}
-	// FIXME: This part is still broken
-	if utils.GitClone("https://github.com/ros2/demos.git", testingSha, "/tmp/testdata/demos", false, true, false) != utils.SuccessfullClone {
-		t.Errorf("Expected to successfully clone git repository given a SHA")
-	}
-	count, err := utils.RunGitCmd("/tmp/testdata/demos", "rev-list", nil, []string{"--all", "--count"}...)
-	if err != nil || strings.TrimSpace(count) != "1" {
-		t.Errorf("Expected to have a shallow clone of the git repository")
-	}
-
-	if utils.GitClone("https://github.com/ros2/demos.git", "rolling", "/tmp/testdata/demos", false, false, false) != utils.SuccessfullClone {
 		t.Errorf("Expected to successfully clone git repository")
 	}
 	if utils.GitClone("https://github.com/ros2/ros2cli", "", "/tmp/testdata/ros2cli", false, false, false) != utils.SuccessfullClone {
@@ -177,12 +185,17 @@ func TestCloneGitRepo(t *testing.T) {
 	if utils.GitClone("https://github.com/ros2/demos.git", "", repoPath, true, false, false) != utils.SuccessfullClone {
 		t.Errorf("Expected to overwrite found git repository")
 	}
-	if utils.GitClone("https://github.com/ros2/demos.git", "", "/tmp/testdata/demos", true, true, false) != utils.SuccessfullClone {
+	if utils.GitClone("https://github.com/ros2/demos.git", "", repoPath, true, true, false) != utils.SuccessfullClone {
 		t.Errorf("Expected to successfully to clone git repository with shallow enabled")
 	}
-	count, err = utils.RunGitCmd("/tmp/testdata/demos", "rev-list", nil, []string{"--all", "--count"}...)
+	count, err := utils.RunGitCmd(repoPath, "rev-list", nil, []string{"--all", "--count"}...)
 	if err != nil || strings.TrimSpace(count) != "1" {
 		t.Errorf("Expected to have a shallow clone of the git repository")
+	}
+
+	testingSha := "839b622bc40ec62307d6ba0615adb9b8bd1cbc30"
+	if utils.GitClone("https://github.com/ros2/demos.git", testingSha, repoPath, true, false, false) != utils.SuccessfullClone {
+		t.Errorf("Expected to successfully clone git repository given a SHA")
 	}
 }
 

--- a/test/git_helpers_test.go
+++ b/test/git_helpers_test.go
@@ -80,6 +80,22 @@ func TestGitStatus(t *testing.T) {
 	}
 }
 
+func TestGetGitBranch(t *testing.T) {
+	if utils.GetGitBranch("/tmp/testdata/valid_repo") != "main" {
+		t.Errorf("Failed to get main branch for valid git repository")
+	}
+}
+
+func TestGetGitCommitSha(t *testing.T) {
+	testingSha := "839b622bc40ec62307d6ba0615adb9b8bd1cbc30"
+	if utils.GitClone("https://github.com/ros2/demos.git", testingSha, "/tmp/testdata/demos", false, false, false) != utils.SuccessfullClone {
+		t.Errorf("Expected to successfully clone git repository")
+	}
+	if utils.GetGitCommitSha("/tmp/testdata/demos") != testingSha {
+		t.Errorf("Failed to pull valid repository.")
+	}
+}
+
 func TestGitPull(t *testing.T) {
 	if utils.GitClone("https://github.com/ros2/demos.git", "rolling", "/tmp/testdata/demos", false, false, false) != utils.SuccessfullClone {
 		t.Errorf("Expected to successfully clone git repository")
@@ -109,9 +125,44 @@ func TestCheckGitUrl(t *testing.T) {
 	}
 }
 
+func TestIsValidCommitSha(t *testing.T) {
+	if !utils.IsValidSha("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391") {
+		t.Errorf("Expected to return valid SHA")
+	}
+	if !utils.IsValidSha("839b622") {
+		t.Errorf("Expected to return valid SHA")
+	}
+	if utils.IsValidSha("INVALIDSHA123456789012345678901234567890") {
+		t.Errorf("Expected to return invalid SHA")
+	}
+	if utils.IsValidSha("11111111111111111111111111111111111111111") {
+		t.Errorf("Expected to return invalid SHA. Invalid length (41 chars)")
+	}
+	if utils.IsValidSha("") {
+		t.Errorf("Expected to return invalid SHA. Invalid length (0 chars)")
+	}
+	if utils.IsValidSha("999999") {
+		t.Errorf("Expected to return invalid SHA. Invalid length (6 chars)")
+	}
+}
+
 func TestCloneGitRepo(t *testing.T) {
 	repoPath := "/tmp/testdata/demos_clone"
 	if utils.GitClone("https://github.com/ros2/demos.git", "rolling", repoPath, false, false, false) != utils.SuccessfullClone {
+	testingSha := "839b622bc40ec62307d6ba0615adb9b8bd1cbc30"
+	if utils.GitClone("https://github.com/ros2/demos.git", testingSha, "/tmp/testdata/demos", false, false, false) != utils.SuccessfullClone {
+		t.Errorf("Expected to successfully clone git repository given a SHA")
+	}
+	// FIXME: This part is still broken
+	if utils.GitClone("https://github.com/ros2/demos.git", testingSha, "/tmp/testdata/demos", false, true, false) != utils.SuccessfullClone {
+		t.Errorf("Expected to successfully clone git repository given a SHA")
+	}
+	count, err := utils.RunGitCmd("/tmp/testdata/demos", "rev-list", nil, []string{"--all", "--count"}...)
+	if err != nil || strings.TrimSpace(count) != "1" {
+		t.Errorf("Expected to have a shallow clone of the git repository")
+	}
+
+	if utils.GitClone("https://github.com/ros2/demos.git", "rolling", "/tmp/testdata/demos", false, false, false) != utils.SuccessfullClone {
 		t.Errorf("Expected to successfully clone git repository")
 	}
 	if utils.GitClone("https://github.com/ros2/ros2cli", "", "/tmp/testdata/ros2cli", false, false, false) != utils.SuccessfullClone {
@@ -129,7 +180,7 @@ func TestCloneGitRepo(t *testing.T) {
 	if utils.GitClone("https://github.com/ros2/demos.git", "", "/tmp/testdata/demos", true, true, false) != utils.SuccessfullClone {
 		t.Errorf("Expected to successfully to clone git repository with shallow enabled")
 	}
-	count, err := utils.RunGitCmd("/tmp/testdata/demos", "rev-list", nil, []string{"--all", "--count"}...)
+	count, err = utils.RunGitCmd("/tmp/testdata/demos", "rev-list", nil, []string{"--all", "--count"}...)
 	if err != nil || strings.TrimSpace(count) != "1" {
 		t.Errorf("Expected to have a shallow clone of the git repository")
 	}

--- a/test/git_helpers_test.go
+++ b/test/git_helpers_test.go
@@ -81,12 +81,16 @@ func TestGitStatus(t *testing.T) {
 }
 
 func TestGetGitBranch(t *testing.T) {
-	if utils.GetGitBranch("/tmp/testdata/valid_repo") != "main" {
+	testingBranch := "jazzy"
+	repoPath := "/tmp/testdata/demos_branch"
+	if utils.GitClone("https://github.com/ros2/demos.git", testingBranch, repoPath, true, false, false) != utils.SuccessfullClone {
+		t.Errorf("Expected to successfully clone git repository")
+	}
+	if utils.GetGitBranch(repoPath) != testingBranch {
 		t.Errorf("Failed to get main branch for valid git repository")
 	}
 	testingTag := "0.34.0"
-	repoPath := "/tmp/testdata/demos_branch"
-	if utils.GitClone("https://github.com/ros2/demos.git", testingTag, repoPath, false, false, false) != utils.SuccessfullClone {
+	if utils.GitClone("https://github.com/ros2/demos.git", testingTag, repoPath, true, false, false) != utils.SuccessfullClone {
 		t.Errorf("Expected to successfully clone git repository")
 	}
 	obtainedTag := utils.GetGitBranch(repoPath)

--- a/test/nested_example.repos
+++ b/test/nested_example.repos
@@ -1,0 +1,6 @@
+repositories:
+  naoqi_driver2:
+    type: git
+    url: https://github.com/ros-naoqi/naoqi_driver2
+    version: main
+

--- a/test/repos_helpers_test.go
+++ b/test/repos_helpers_test.go
@@ -97,3 +97,40 @@ func TestFindDirectory(t *testing.T) {
 	}
 
 }
+
+func TestParseRepositoryInfo(t *testing.T) {
+	repository := utils.ParseRepositoryInfo("", false)
+	if repository.Type != "" || repository.Version != "" || repository.URL != "" {
+		t.Errorf("Expected to get an empty repository object")
+	}
+	repoPath := "/tmp/testdata/demos_parse"
+	repoURL := "https://github.com/ros2/demos.git"
+	repoVersion := "rolling"
+	if utils.GitClone(repoURL, repoVersion, repoPath, true, false, false) != utils.SuccessfullClone {
+		t.Errorf("Expected to successfully clone git repository")
+	}
+
+	repository = utils.ParseRepositoryInfo(repoPath, false)
+	if repository.Type != "git" || repository.Version != repoVersion || repository.URL != repoURL {
+		t.Errorf("Failed to properly parse the repository info using branch")
+	}
+
+	repoVersion = "839b622bc40ec62307d6ba0615adb9b8bd1cbc30"
+	if utils.GitClone(repoURL, repoVersion, repoPath, true, false, false) != utils.SuccessfullClone {
+		t.Errorf("Expected to successfully clone git repository")
+	}
+	repository = utils.ParseRepositoryInfo(repoPath, true)
+	if repository.Type != "git" || repository.Version != repoVersion || repository.URL != repoURL {
+		t.Errorf("Failed to properly parse the repository info using commit")
+	}
+
+	repoVersion = "0.34.0"
+	if utils.GitClone(repoURL, repoVersion, repoPath, true, false, false) != utils.SuccessfullClone {
+		t.Errorf("Expected to successfully clone git repository")
+	}
+	repository = utils.ParseRepositoryInfo(repoPath, false)
+	if repository.Type != "git" || repository.Version != repoVersion || repository.URL != repoURL {
+		t.Errorf("Failed to properly parse the repository info using tag")
+	}
+
+}

--- a/utils/git_helpers.go
+++ b/utils/git_helpers.go
@@ -81,6 +81,14 @@ func GetGitBranch(path string) string {
 	if err != nil {
 		fmt.Printf("Failed to get current Git branch of %s. Error: %s", path, err)
 	}
+	if output != "" {
+		return strings.TrimSpace(output)
+	}
+	checkTagArgs := []string{"--points-at", "HEAD"}
+	output, err = RunGitCmd(path, "tag", nil, checkTagArgs...)
+	if err != nil {
+		fmt.Printf("Failed to get current Git branch of %s. Error: %s", path, err)
+	}
 	return strings.TrimSpace(output)
 }
 
@@ -89,6 +97,15 @@ func GetGitCommitSha(path string) string {
 	output, err := RunGitCmd(path, "rev-parse", nil, cmdArgs...)
 	if err != nil {
 		fmt.Printf("Failed to get current Git commit of %s. Error: %s", path, err)
+	}
+	return strings.TrimSpace(output)
+}
+
+func GetGitRemoteURL(path string) string {
+	cmdArgs := []string{"get-url", "origin"}
+	output, err := RunGitCmd(path, "remote", nil, cmdArgs...)
+	if err != nil {
+		fmt.Printf("Failed to get URL for the origin remote of %s. Error: %s", path, err)
 	}
 	return strings.TrimSpace(output)
 }

--- a/utils/repos_helpers.go
+++ b/utils/repos_helpers.go
@@ -116,3 +116,19 @@ func FindDirectory(rootPath string, targetDir string) (string, error) {
 	}
 	return dirPath, nil
 }
+
+// ParseRepositoryInfo Create a Repository object containing the given repository info
+func ParseRepositoryInfo(repoPath string, useCommit bool) Repository {
+	var repository Repository
+	if !IsGitRepository(repoPath) {
+		return repository
+	}
+	repository.Type = "git"
+	repository.URL = GetGitRemoteURL(repoPath)
+	if useCommit {
+		repository.Version = GetGitCommitSha(repoPath)
+	} else {
+		repository.Version = GetGitBranch(repoPath)
+	}
+	return repository
+}

--- a/utils/repos_helpers.go
+++ b/utils/repos_helpers.go
@@ -10,7 +10,7 @@ import (
 )
 
 type RepositoryJob struct {
-	DirName string
+	RepoPath string
 	Repo    Repository
 }
 


### PR DESCRIPTION
This command can be used to report the current version of the repositories found in the given path. It supports reporting the version given the branches, tags, or commits found.