### PR TITLE
ref: Improve error message for commit validation

### DIFF
--- a/test/git_helpers_test.go
+++ b/test/git_helpers_test.go
@@ -1,7 +1,6 @@
 package test
 
 import (
-	"fmt"
 	"os"
 	"os/exec"
 	"ripvcs/utils"
@@ -143,11 +142,20 @@ func TestGitLog(t *testing.T) {
 }
 
 func TestCheckGitUrl(t *testing.T) {
-	if utils.IsGitURLValid("https://github.com/ros2/demosasdasd.git", "rolling", false) {
-		t.Errorf("Expected to return invalid URL")
+	if valid, err := utils.IsGitURLValid("https://github.com/ros2/demosasdasd.git", "rolling", false); valid {
+		t.Errorf("Expected to return invalid URL. Error %v", err)
 	}
-	if !utils.IsGitURLValid("https://github.com/ros2/demos.git", "rolling", false) {
-		t.Errorf("Expected to return invalid URL")
+	if valid, err := utils.IsGitURLValid("https://github.com/ros2/demos.git", "rolling", false); !valid {
+		t.Errorf("Expected to return valid URL given a branch. Error %v", err)
+	}
+	if valid, err := utils.IsGitURLValid("https://github.com/ros2/demos.git", "", false); !valid {
+		t.Errorf("Expected to return valid URL given no branch. Error %v", err)
+	}
+	if valid, err := utils.IsGitURLValid("https://github.com/ros2/demos.git", "0.34.0", false); !valid {
+		t.Errorf("Expected to return valid URL given a tag. Error %v", err)
+	}
+	if valid, err := utils.IsGitURLValid("https://github.com/ros2/demos.git", "839b622bc40ec62307d6ba0615adb9b8bd1cbc30", false); valid {
+		t.Errorf("Expected to return invalid URL given a commit SHA. Error %v", err)
 	}
 }
 
@@ -208,21 +216,20 @@ func TestGitSwitch(t *testing.T) {
 	if utils.GitClone("https://github.com/ros2/demos.git", "rolling", repoPath, false, false, false) != utils.SuccessfullClone {
 		t.Errorf("Expected to successfully clone git repository")
 	}
-	output, err := utils.GitSwitch(repoPath, "humble", false, false)
+	_, err := utils.GitSwitch(repoPath, "humble", false, false)
 	if err != nil {
 		t.Errorf("Expected to successfully to switch to a branch. Error %s", err)
 	}
 
-	output, err = utils.GitSwitch(repoPath, "nonexisting", false, false)
+	_, err = utils.GitSwitch(repoPath, "nonexisting", false, false)
 	if err == nil {
 		t.Errorf("Expected to fail to switch to a nonexisting branch.\nError %s", err)
 	}
-	fmt.Println(output)
-	output, err = utils.GitSwitch(repoPath, "nonexisting", true, false)
+	_, err = utils.GitSwitch(repoPath, "nonexisting", true, false)
 	if err != nil {
 		t.Errorf("Expected to successfully to create a new branch.\nError %s", err)
 	}
-	output, err = utils.GitSwitch(repoPath, "0.34.0", false, true)
+	_, err = utils.GitSwitch(repoPath, "0.34.0", false, true)
 	if err != nil {
 		t.Errorf("Expected to successfully to switch to a tag.\nError %s", err)
 	}


### PR DESCRIPTION
The validate command is still not capable of validating whether the given commit sha exist in the remote repository. This commit introduces a clearer error message reflecting this behavior.

Additional changes:
- Fix error in failing test message.

This behavior was found thanks to #13 