### PR TITLE
Improve handling of repository path and Export command

### DIFF
--- a/cmd/export.go
+++ b/cmd/export.go
@@ -25,7 +25,7 @@ If no path is given, it checks the finds any Git repository relative to the curr
 		if len(args) == 0 {
 			root = "."
 		} else {
-			root = args[0]
+			root = utils.GetRepoPath(args[0])
 		}
 		gitRepos := utils.FindGitRepositories(root)
 

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -30,15 +30,21 @@ If no path is given, it checks the finds any Git repository relative to the curr
 		gitRepos := utils.FindGitRepositories(root)
 
 		filePath, _ := cmd.Flags().GetString("output")
+		visualizeOutput, _ := cmd.Flags().GetBool("visualize")
+
+		skipOutputFile := false
 
 		if len(filePath) == 0 {
-			utils.PrintErrorMsg("Missing output file.")
-			os.Exit(1)
+			if visualizeOutput {
+				skipOutputFile = true
+			} else {
+				utils.PrintErrorMsg("Missing output file.")
+				os.Exit(1)
+			}
 		}
 
 		numWorkers, _ := cmd.Flags().GetInt("workers")
 		getCommitsFlag, _ := cmd.Flags().GetBool("commits")
-		visualizeOutput, _ := cmd.Flags().GetBool("visualize")
 
 		// Create a channel to send work to the workers with a buffer size of length gitRepos
 		jobs := make(chan string, len(gitRepos))
@@ -86,10 +92,12 @@ If no path is given, it checks the finds any Git repository relative to the curr
 		if visualizeOutput {
 			fmt.Println(string(yamlData))
 		}
-		err := os.WriteFile(filePath, yamlData, 0644)
-		if err != nil {
-			utils.PrintErrorMsg("Failed to export repositories to yaml file.")
-			os.Exit(1)
+		if !skipOutputFile {
+			err := os.WriteFile(filePath, yamlData, 0644)
+			if err != nil {
+				utils.PrintErrorMsg("Failed to export repositories to yaml file.")
+				os.Exit(1)
+			}
 		}
 	},
 }

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -26,7 +26,7 @@ import cycle.`,
 		if len(args) == 0 {
 			cloningPath = "."
 		} else {
-			cloningPath = args[0]
+			cloningPath = utils.GetRepoPath(args[0])
 		}
 
 		// Get arguments

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -21,7 +21,7 @@ If no path is given, it gets the logs of any Git repository relative to the curr
 		if len(args) == 0 {
 			root = "."
 		} else {
-			root = args[0]
+			root = utils.GetRepoPath(args[0])
 		}
 		gitRepos := utils.FindGitRepositories(root)
 

--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -21,7 +21,7 @@ Update all repositories found relative to the given path or to the current path.
 		if len(args) == 0 {
 			root = "."
 		} else {
-			root = args[0]
+			root = utils.GetRepoPath(args[0])
 		}
 		gitRepos := utils.FindGitRepositories(root)
 

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -21,7 +21,7 @@ If no path is given, it checks the status of any Git repository relative to the 
 		if len(args) == 0 {
 			root = "."
 		} else {
-			root = args[0]
+			root = utils.GetRepoPath(args[0])
 		}
 		gitRepos := utils.FindGitRepositories(root)
 

--- a/cmd/switch.go
+++ b/cmd/switch.go
@@ -19,33 +19,12 @@ var switchCmd = &cobra.Command{
 
 It allows to easily run Git switch operation on the given repository.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		var repoName string
+		// var repoName string
 		if len(args) == 0 {
-			fmt.Println("Repository Name or Path not given")
+			utils.PrintErrorMsg("Repository Name or Path not given\n")
 			os.Exit(1)
 		}
-		repoName = args[0]
-
-		var repoPath string
-		// check if input is not a path
-		if repoNameInfo, err := os.Stat(repoName); err != nil {
-			if os.IsNotExist(err) {
-				foundRepoPath, findErr := utils.FindDirectory(".", repoName)
-				if findErr != nil {
-					fmt.Printf("Failed to find directory named %s. Error: %s\n", repoPath, findErr)
-					os.Exit(1)
-				}
-				repoPath = foundRepoPath
-			} else {
-				fmt.Printf("Error checking repoName: %s\n", err)
-				os.Exit(1)
-			}
-		} else if !repoNameInfo.IsDir() {
-			fmt.Printf("%s is not a directory\n", repoName)
-			os.Exit(1)
-		} else {
-			repoPath = repoName
-		}
+		repoPath := utils.GetRepoPath(args[0])
 
 		if !utils.IsGitRepository(repoPath) {
 			fmt.Println("Directory given is not a git repository")

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -22,7 +22,7 @@ and bring back staged changes.`,
 		if len(args) == 0 {
 			root = "."
 		} else {
-			root = args[0]
+			root = utils.GetRepoPath(args[0])
 		}
 		gitRepos := utils.FindGitRepositories(root)
 

--- a/utils/repos_helpers.go
+++ b/utils/repos_helpers.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,7 +12,7 @@ import (
 
 type RepositoryJob struct {
 	RepoPath string
-	Repo    Repository
+	Repo     Repository
 }
 
 type Repository struct {
@@ -131,4 +132,28 @@ func ParseRepositoryInfo(repoPath string, useCommit bool) Repository {
 		repository.Version = GetGitBranch(repoPath)
 	}
 	return repository
+}
+
+func GetRepoPath(repoName string) string {
+	repoNameInfo, err := os.Stat(repoName)
+
+	if err == nil {
+		if !repoNameInfo.IsDir() {
+			PrintErrorMsg(fmt.Sprintf("%s is not a directory\n", repoName))
+			os.Exit(1)
+		}
+		return repoName
+	}
+
+	if !os.IsNotExist(err) {
+		PrintErrorMsg(fmt.Sprintf("Error checking repository: %s\n", repoName))
+		os.Exit(1)
+	}
+
+	foundRepoPath, findErr := FindDirectory(".", repoName)
+	if findErr != nil {
+		PrintErrorMsg(fmt.Sprintf("Failed to find directory named %s. Error: %s\n", repoName, findErr))
+		os.Exit(1)
+	}
+	return foundRepoPath
 }


### PR DESCRIPTION
## Changes

- Provide similar functionality of searching for the repository path as it was done for the switch command. Now, if you only care about the status of a single repository you can do something like this
  - `rv status src/my_repo`
  - `rv status my_repo`

- Support visualization flag for export command without having to specify an output file. I find this approach more user-friendly.