### PR TITLE
Support rosinstall file format in import command

### DIFF
--- a/cmd/import.go
+++ b/cmd/import.go
@@ -26,7 +26,7 @@ import cycle.`,
 		if len(args) == 0 {
 			cloningPath = "."
 		} else {
-			cloningPath = utils.GetRepoPath(args[0])
+			cloningPath = args[0]
 		}
 
 		// Get arguments

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -83,7 +83,7 @@ func singleCloneSweep(root string, filePath string, numWorkers int, overwriteExi
 			for job := range jobs {
 				if job.Repo.Type != "git" {
 					utils.PrintRepoEntry(job.RepoPath, "")
-					utils.PrintErrorMsg("Unsupported repository type.\n")
+					utils.PrintErrorMsg(fmt.Sprintf("Unsupported repository type %s.\n", job.Repo.Type))
 					results <- false
 				} else {
 					success := false

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -46,7 +46,7 @@ and that the provided version exist.`,
 				for job := range jobs {
 					if job.Repo.Type != "git" {
 						utils.PrintRepoEntry(job.RepoPath, "")
-						utils.PrintErrorMsg("Unsupported repository type.\n")
+						utils.PrintErrorMsg(fmt.Sprintf("Unsupported repository type %s.\n", job.Repo.Type))
 						results <- false
 					} else {
 						success := utils.PrintCheckGit(job.RepoPath, job.Repo.URL, job.Repo.Version, false)

--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,10 @@ go 1.22.0
 require (
 	github.com/jesseduffield/yaml v2.1.0+incompatible
 	github.com/spf13/cobra v1.8.0
+	gopkg.in/yaml.v2 v2.4.0
 )
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/test/repos_helpers_test.go
+++ b/test/repos_helpers_test.go
@@ -27,9 +27,43 @@ func TestReposFile(t *testing.T) {
 }
 
 func TestParsingReposFile(t *testing.T) {
-	_, err := utils.ParseReposFile("./valid_example.repos")
+	repo, err := utils.ParseReposFile("./valid_example.repos")
 	if err != nil {
-		t.Errorf("Expected to report a valid file")
+		t.Errorf("Expected to parse .repos file")
+	}
+	if len(repo.Repositories) != 8 {
+		t.Errorf("The parsed repositories from .repos file do not match the expected values.")
+	}
+	expectedType := "git"
+	if repoType := repo.Repositories["demos_rolling"].Type; repoType != expectedType {
+		t.Errorf("Expected to have %s as repo type. Got: %s", expectedType, repoType)
+	}
+	expectedUrl := "https://github.com/ros2/demos.git"
+	if repoUrl := repo.Repositories["demos_rolling"].URL; repoUrl != expectedUrl {
+		t.Errorf("Expected to have %s as repo url. Got: %s", expectedUrl, repoUrl)
+	}
+	expectedVersion := "rolling"
+	if repoVersion := repo.Repositories["demos_rolling"].Version; repoVersion != expectedVersion {
+		t.Errorf("Expected to have %s as repo version. Got: %s", expectedVersion, repoVersion)
+	}
+	repo, err = utils.ParseReposFile("./valid_example.rosinstall")
+	if err != nil {
+		t.Errorf("Expected to parse .rosinstall file")
+	}
+	if len(repo.Repositories) != 2 {
+		t.Errorf("The parsed repositories from .rosinstall do not match the expected values.")
+	}
+	expectedType = "git"
+	if repoType := repo.Repositories["moveit_msgs"].Type; repoType != expectedType {
+		t.Errorf("Expected to have %s as repo type. Got: %s", expectedType, repoType)
+	}
+	expectedUrl = "https://github.com/moveit/moveit_msgs.git"
+	if repoUrl := repo.Repositories["moveit_msgs"].URL; repoUrl != expectedUrl {
+		t.Errorf("Expected to have %s as repo url. Got: %s", expectedUrl, repoUrl)
+	}
+	expectedVersion = "master"
+	if repoVersion := repo.Repositories["moveit_msgs"].Version; repoVersion != expectedVersion {
+		t.Errorf("Expected to have %s as repo version. Got: %s", expectedVersion, repoVersion)
 	}
 
 	err = os.WriteFile("/tmp/empty_file.repos", []byte{}, 0644)
@@ -75,19 +109,19 @@ func TestFindDirectory(t *testing.T) {
 		t.Errorf("Wrong directory found. Expected %v, found %v", path, repoPath)
 	}
 
-	repoPath, err = utils.FindDirectory("", "sadsd")
+	_, err = utils.FindDirectory("", "sadsd")
 	if err == nil {
 		t.Errorf("Expected to failed to find directory, based on empty rootPath")
 	}
-	repoPath, err = utils.FindDirectory("/tmp", "")
+	_, err = utils.FindDirectory("/tmp", "")
 	if err == nil {
 		t.Errorf("Expected to failed to find directory, based on empty targetDir")
 	}
-	repoPath, err = utils.FindDirectory("/sdasd", "")
+	_, err = utils.FindDirectory("/sdasd", "")
 	if err == nil {
 		t.Errorf("Expected to failed to find directory, based on nonexisting rootPath")
 	}
-	repoPath, err = utils.FindDirectory("/tmp", "/tmp/testdata/")
+	_, err = utils.FindDirectory("/tmp", "/tmp/testdata/")
 	if err == nil {
 		t.Errorf("Expected to failed to find directory, targetDir being a path")
 	}

--- a/test/valid_example.rosinstall
+++ b/test/valid_example.rosinstall
@@ -1,0 +1,8 @@
+- git:
+    local-name: moveit_msgs
+    uri: https://github.com/moveit/moveit_msgs.git
+    version: master
+- git:
+    local-name: moveit_resources
+    uri: https://github.com/moveit/moveit_resources.git
+    version: master

--- a/utils/git_helpers.go
+++ b/utils/git_helpers.go
@@ -3,7 +3,6 @@
 package utils
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -198,7 +197,7 @@ func GitSwitch(path string, branch string, createBranch bool, detachHead bool) (
 
 	output, err := RunGitCmd(path, "switch", nil, cmdArgs...)
 	if err != nil {
-		switchError := errors.New(fmt.Sprintf("Failed to switch branch of repository %s to %s. Error: %s", path, branch, err))
+		switchError := fmt.Errorf("failed to switch branch of repository %s to %s. Error: %s", path, branch, err)
 		return "", switchError
 	}
 	return output, nil

--- a/utils/repos_helpers.go
+++ b/utils/repos_helpers.go
@@ -29,11 +29,11 @@ type Config struct {
 func IsReposFileValid(filePath string) error {
 
 	if _, err := os.Stat(filePath); os.IsNotExist(err) {
-		return errors.New("Error: File does not exist!")
+		return errors.New("error: File does not exist")
 	}
 
 	if !strings.HasSuffix(filePath, ".repos") {
-		return errors.New("Error: File given does not have a valid .repos extension!")
+		return errors.New("error: File given does not have a valid .repos extension")
 	}
 	return nil
 }
@@ -47,7 +47,7 @@ func ParseReposFile(filePath string) (*Config, error) {
 	yamlFile, err := os.ReadFile(filePath)
 
 	if err != nil {
-		errorMsg := "Failed to read .repos file"
+		errorMsg := "failed to read .repos file"
 		// fmt.Printf("%s: %s\n", errorMsg, err)
 		return nil, errors.New(errorMsg)
 	}
@@ -56,13 +56,13 @@ func ParseReposFile(filePath string) (*Config, error) {
 	var config Config
 	err = yaml.Unmarshal(yamlFile, &config)
 	if err != nil {
-		errorMsg := "Failed to parse .repos file"
+		errorMsg := "failed to parse .repos file"
 		// fmt.Printf("%s: %s\n", errorMsg, err)
 		return nil, errors.New(errorMsg)
 	}
 
 	if len(config.Repositories) == 0 {
-		errorMsg := "Empty .repos file given"
+		errorMsg := "empty .repos file given"
 		// fmt.Printf("%s: %s\n", errorMsg, err)
 		return nil, errors.New(errorMsg)
 	}
@@ -89,16 +89,16 @@ func FindReposFiles(rootPath string) ([]string, error) {
 // FindDirectory Search for a targetDir given a rootPath
 func FindDirectory(rootPath string, targetDir string) (string, error) {
 	if len(rootPath) == 0 {
-		return "", errors.New("Empty rootPath given")
+		return "", errors.New("empty rootPath given")
 	}
 	if len(targetDir) == 0 {
-		return "", errors.New("Empty targetDir given")
+		return "", errors.New("empty targetDir given")
 	}
 	if rootInfo, err := os.Stat(rootPath); err != nil || !rootInfo.IsDir() {
 		return "", err
 	}
 	if _, err := os.Stat(targetDir); err == nil {
-		return "", errors.New("targetDir is a Path!. Expected just a name.")
+		return "", errors.New("targetDir is a Path!. Expected just a name")
 	}
 
 	var dirPath string


### PR DESCRIPTION
This addresses the Feature Request #1 

## Additional Changes:

- Fix linter warning
- Revert directory search for import command.