### PR TITLE
Add exclude functionality to import command

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22.x'
+          go-version: '1.24.x'
       - name: Install dependencies
         run: go get .
       - name: Build
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22.x'
+          go-version: '1.24.x'
       - name: Install dependencies
         run: go get .
       - name: Test with the Go CLI

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22.x'
+          go-version: '1.24.x'
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,17 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - 'v*.*.*'
   workflow_dispatch:
+    inputs:
+      version_bump:
+        description: 'Version bump type'
+        type: choice
+        required: true
+        default: 'patch'
+        options:
+          - major
+          - minor
+          - patch
 
 jobs:
   test:
@@ -13,12 +20,83 @@ jobs:
       - name: Checkout the project
         uses: actions/checkout@v4
         with:
-          submodules: recursive
           fetch-depth: 0
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
           go-version: '1.24.x'
+
+      - name: Get Latest Tag
+        run: |
+          latest_tag=$(git describe --tags $(git rev-list --tags --max-count=1) || echo "v0.0.0")
+
+          if ! [[ $latest_tag =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: Tag format is invalid. Expected format: vX.X.X"
+            exit 1
+          fi
+
+          echo "Latest tag: $latest_tag"
+          echo "latest_tag=$latest_tag" >> $GITHUB_ENV
+
+      - name: Check for changes since last release
+        run: |
+          if [ -z "$(git diff --name-only ${{ env.latest_tag }})" ]; then
+            echo "No changes detected since last release"
+            exit 1
+          fi
+
+      - name: Calculate next version
+        run: |
+          echo "Latest tag: ${{ env.latest_tag }}"
+          IFS='.' read -r major minor patch <<< "${{ env.latest_tag }}"
+
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            if [[ "${{ inputs.version_bump }}" == "major" ]]; then
+              major=$((major + 1))
+              minor=0
+              patch=0
+            elif [[ "${{ inputs.version_bump }}" == "minor" ]]; then
+              minor=$((minor + 1))
+              patch=0
+            else
+              patch=$((patch + 1))
+            fi
+          fi
+
+          new_tag="$major.$minor.$patch"
+
+          if ! [[ $new_tag =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: New tag's format is invalid. Expected format: vX.X.X"
+            exit 1
+          fi
+          echo "New tag: $new_tag"
+
+      - name: Update version.go
+        run: |
+          VERSION=$(git describe --tags --abbrev=0)  # Get the latest tag
+          COMMIT=$(git rev-parse --short HEAD)
+          DATE=$(date +'%d.%m.%Y')
+          sed -i "s/Version   = \".*\"/Version   = \"$VERSION\"/" ./cmd/version.go
+          sed -i "s/Commit    = \".*\"/Commit    = \"$COMMIT\"/" ./cmd/version.go
+          sed -i "s/BuildDate = \".*\"/BuildDate = \"$DATE\"/" ./cmd/version.go
+
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git add .
+          git commit -m "Update version.go for release $VERSION"
+          git push
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_API_TOKEN }}
+
+      - name: Create and Push Tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag ${{ env.new_tag }}
+          git push origin ${{ env.new_tag }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_API_TOKEN }}
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
@@ -26,4 +104,4 @@ jobs:
           version: latest
           args: release --clean
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # 🎒 ripvcs
 
-**PRE-RELEASE: Heavily developing this tool at the moment.**
-
 <p align="center">
   <img width="33%" src="./assets/cat_sorter.jpeg" />
 </p>

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Usage:
 
 Flags:
   -d, --depth-recursive int   Regulates how many levels the recursive dependencies would be cloned. (default -1)
-  -x, --exclude strings       List of files or directories to exclude
+  -x, --exclude strings       List of files and/or directories to exclude when performing a recursive import
   -f, --force                 Force overwriting existing repositories
   -h, --help                  help for import
   -i, --input .repos          Path to input .repos file
@@ -118,7 +118,17 @@ repositories:
   default_demos:
     type: git
     url: https://github.com/ros2/demos
+    exclude: []
 ```
+
+### Import exclusion
+
+It is possible to exclude files or directories when doing recursive import. This can be done either
+through the use of the `--exclude / -x` flag accompanied by the name of the `.repos` file or a
+directory within the path.
+
+Additionally, it is possible to add a `exclude` attribute to the `.repos` file to hard-code what
+files to exclude during import. An example of this can be seen in [example_nested.repos](./test/example_nested.repos)
 
 ## Related Project
 

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -57,7 +57,7 @@ If no path is given, it checks the finds any Git repository relative to the curr
 		// Initialize the repositories map
 		config.Repositories = make(map[string]utils.Repository)
 		// Iterate over the numWorkers
-		for i := 0; i < numWorkers; i++ {
+		for range numWorkers {
 			go func() {
 				for repoPath := range jobs {
 					var repoPathName string
@@ -80,7 +80,7 @@ If no path is given, it checks the finds any Git repository relative to the curr
 		close(jobs) // Close channel to signal no more work will be sent
 
 		// wait for all goroutines to finish
-		for i := 0; i < numWorkers; i++ {
+		for range numWorkers {
 			<-done
 		}
 		close(repositories)

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -81,7 +81,7 @@ func singleCloneSweep(root string, filePath string, numWorkers int, overwriteExi
 	// Create a channel to indicate when the go routines have finished
 	done := make(chan bool)
 
-	for i := 0; i < numWorkers; i++ {
+	for range numWorkers {
 		go func() {
 			for job := range jobs {
 				if job.Repo.Type != "git" {
@@ -90,7 +90,7 @@ func singleCloneSweep(root string, filePath string, numWorkers int, overwriteExi
 					results <- false
 				} else {
 					success := false
-					for i := 0; i < numRetries; i++ {
+					for range numRetries {
 						success = utils.PrintGitClone(job.Repo.URL, job.Repo.Version, job.RepoPath, overwriteExisting, shallowClone, false)
 						if success {
 							break
@@ -108,7 +108,7 @@ func singleCloneSweep(root string, filePath string, numWorkers int, overwriteExi
 	}
 	close(jobs)
 	// wait for all goroutines to finish
-	for i := 0; i < numWorkers; i++ {
+	for range numWorkers {
 		<-done
 	}
 	close(results)
@@ -155,15 +155,15 @@ func nestedImportClones(cloningPath string, initialFilePath string, depthRecursi
 				}
 				cleanRelPath := filepath.Clean(relPath)
 				if cleanRelPath == cleanExcludePath || strings.HasPrefix(cleanRelPath, cleanExcludePath+string(os.PathSeparator)) {
-				exclude = true
-				break
-			}
+					exclude = true
+					break
+				}
 			}
 			if exclude {
 				utils.PrintRepoEntry(fmt.Sprintf("Excluding %s", filePathToClone), "")
 				continue
 			}
-			
+
 			if _, ok := clonedReposFiles[filePathToClone]; !ok {
 				validFiles = singleCloneSweep(cloningPath, filePathToClone, numWorkers, overwriteExisting, shallowClone, numRetries)
 				clonedReposFiles[filePathToClone] = true
@@ -179,5 +179,4 @@ func nestedImportClones(cloningPath string, initialFilePath string, depthRecursi
 		}
 		cloneSweepCounter++
 	}
-
 }

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -16,6 +16,7 @@ var logCmd = &cobra.Command{
 	Long: `Get logs of all repositories.
 
 If no path is given, it gets the logs of any Git repository relative to the current path.`,
+
 	Run: func(cmd *cobra.Command, args []string) {
 		var root string
 		if len(args) == 0 {
@@ -37,7 +38,7 @@ If no path is given, it gets the logs of any Git repository relative to the curr
 		done := make(chan bool)
 
 		// Iterate over the numWorkers
-		for i := 0; i < numWorkers; i++ {
+		for range numWorkers {
 			go func() {
 				for repo := range jobs {
 					utils.PrintGitLog(repo, onelineFlag, numCommits)
@@ -52,7 +53,7 @@ If no path is given, it gets the logs of any Git repository relative to the curr
 		close(jobs) // Close channel to signal no more work will be sent
 
 		// wait for all goroutines to finish
-		for i := 0; i < numWorkers; i++ {
+		for range numWorkers {
 			<-done
 		}
 	},

--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -35,7 +35,7 @@ Update all repositories found relative to the given path or to the current path.
 		done := make(chan bool)
 
 		// Iterate over the numWorkers
-		for i := 0; i < numWorkers; i++ {
+		for range numWorkers {
 			go func() {
 				for repo := range jobs {
 					utils.PrintGitPull(repo)
@@ -50,7 +50,7 @@ Update all repositories found relative to the given path or to the current path.
 		close(jobs) // Close channel to signal no more work will be sent
 
 		// wait for all goroutines to finish
-		for i := 0; i < numWorkers; i++ {
+		for range numWorkers {
 			<-done
 		}
 	},

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -36,7 +36,7 @@ If no path is given, it checks the status of any Git repository relative to the 
 		done := make(chan bool)
 
 		// Iterate over the numWorkers
-		for i := 0; i < numWorkers; i++ {
+		for range numWorkers {
 			go func() {
 				for repo := range jobs {
 					utils.PrintGitStatus(repo, skipEmtpy, plainStatus)
@@ -51,7 +51,7 @@ If no path is given, it checks the status of any Git repository relative to the 
 		close(jobs) // Close channel to signal no more work will be sent
 
 		// wait for all goroutines to finish
-		for i := 0; i < numWorkers; i++ {
+		for range numWorkers {
 			<-done
 		}
 	},

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -36,7 +36,7 @@ and bring back staged changes.`,
 		done := make(chan bool)
 
 		// Iterate over the numWorkers
-		for i := 0; i < numWorkers; i++ {
+		for range numWorkers {
 			go func() {
 				for repo := range jobs {
 					utils.PrintGitSync(repo)
@@ -51,7 +51,7 @@ and bring back staged changes.`,
 		close(jobs) // Close channel to signal no more work will be sent
 
 		// wait for all goroutines to finish
-		for i := 0; i < numWorkers; i++ {
+		for range numWorkers {
 			<-done
 		}
 	},

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -41,7 +41,7 @@ and that the provided version exist.`,
 		// Create a channel to indicate when the go routines have finished
 		done := make(chan bool)
 
-		for i := 0; i < numWorkers; i++ {
+		for range numWorkers {
 			go func() {
 				for job := range jobs {
 					if job.Repo.Type != "git" {
@@ -62,7 +62,7 @@ and that the provided version exist.`,
 		}
 		close(jobs)
 		// wait for all goroutines to finish
-		for i := 0; i < numWorkers; i++ {
+		for range numWorkers {
 			<-done
 		}
 		close(results)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module ripvcs
 
-go 1.22.0
+go 1.24.0
 
 require (
 	github.com/jesseduffield/yaml v2.1.0+incompatible

--- a/test/git_helpers_test.go
+++ b/test/git_helpers_test.go
@@ -38,6 +38,9 @@ func createTestFiles() {
 	// Create nested directories and .git repository
 	path = "/tmp/testdata/normal_dir/another_repo/"
 	err = os.MkdirAll(path, 0755)
+	if err != nil {
+		panic(err)
+	}
 	cmd = exec.Command("git", "init")
 	cmd.Dir = path
 	_, err = cmd.CombinedOutput()

--- a/test/nested_example.repos
+++ b/test/nested_example.repos
@@ -3,4 +3,14 @@ repositories:
     type: git
     url: https://github.com/ros-naoqi/naoqi_driver2
     version: main
+  twist_mux:
+    type: git
+    url: https://github.com/ros-teleop/twist_mux.git
+    version: humble
+    exclude: [twist_mux_deps.repos]
+  twist_mux_2/stuff:
+    type: git
+    url: https://github.com/ros-teleop/twist_mux.git
+    version: humble
+    exclude: [stuff]
 

--- a/test/repos_helpers_test.go
+++ b/test/repos_helpers_test.go
@@ -129,7 +129,6 @@ func TestFindDirectory(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-
 }
 
 func TestParseRepositoryInfo(t *testing.T) {
@@ -166,5 +165,4 @@ func TestParseRepositoryInfo(t *testing.T) {
 	if repository.Type != "git" || repository.Version != repoVersion || repository.URL != repoURL {
 		t.Errorf("Failed to properly parse the repository info using tag")
 	}
-
 }

--- a/utils/git_helpers.go
+++ b/utils/git_helpers.go
@@ -21,7 +21,6 @@ const (
 
 // IsGitRepository checks if a directory is a git repository
 func IsGitRepository(dir string) bool {
-	// FIXME: Check if dir is a directory
 	gitDir := filepath.Join(dir, ".git")
 	_, err := os.Stat(gitDir)
 	return err == nil
@@ -42,7 +41,7 @@ func FindGitRepositories(root string) []string {
 		return nil // Continue walking
 	})
 	if err != nil {
-		fmt.Println("Error: ", err)
+		PrintErrorMsg(fmt.Sprintf("Error: %s", err))
 	}
 	return gitRepos
 }
@@ -69,7 +68,7 @@ func GetGitStatus(path string, plainStatus bool) string {
 	}
 	output, err := RunGitCmd(path, "status", nil, statusArgs...)
 	if err != nil {
-		fmt.Printf("Failed to check Git status of %s. Error: %s", path, err)
+		PrintErrorMsg(fmt.Sprintf("Failed to check Git status of %s. Error: %s", path, err))
 	}
 	return output
 }
@@ -78,7 +77,7 @@ func GetGitStatus(path string, plainStatus bool) string {
 func GetGitBranch(path string) string {
 	output, err := RunGitCmd(path, "branch", nil, "--show-current")
 	if err != nil {
-		fmt.Printf("Failed to get current Git branch of %s. Error: %s", path, err)
+		PrintErrorMsg(fmt.Sprintf("Failed to get current Git branch of %s. Error: %s", path, err))
 	}
 	if output != "" {
 		return strings.TrimSpace(output)
@@ -86,7 +85,7 @@ func GetGitBranch(path string) string {
 	checkTagArgs := []string{"--points-at", "HEAD"}
 	output, err = RunGitCmd(path, "tag", nil, checkTagArgs...)
 	if err != nil {
-		fmt.Printf("Failed to get current Git branch of %s. Error: %s", path, err)
+		PrintErrorMsg(fmt.Sprintf("Failed to get current Git branch of %s. Error: %s", path, err))
 	}
 	return strings.TrimSpace(output)
 }
@@ -95,7 +94,7 @@ func GetGitCommitSha(path string) string {
 	cmdArgs := []string{"--verify", "HEAD"}
 	output, err := RunGitCmd(path, "rev-parse", nil, cmdArgs...)
 	if err != nil {
-		fmt.Printf("Failed to get current Git commit of %s. Error: %s", path, err)
+		PrintErrorMsg(fmt.Sprintf("Failed to get current Git commit of %s. Error: %s", path, err))
 	}
 	return strings.TrimSpace(output)
 }
@@ -104,7 +103,7 @@ func GetGitRemoteURL(path string) string {
 	cmdArgs := []string{"get-url", "origin"}
 	output, err := RunGitCmd(path, "remote", nil, cmdArgs...)
 	if err != nil {
-		fmt.Printf("Failed to get URL for the origin remote of %s. Error: %s", path, err)
+		PrintErrorMsg(fmt.Sprintf("Failed to get URL for the origin remote of %s. Error: %s", path, err))
 	}
 	return strings.TrimSpace(output)
 }
@@ -113,7 +112,7 @@ func GetGitRemoteURL(path string) string {
 func PullGitRepo(path string) string {
 	output, err := RunGitCmd(path, "pull", nil)
 	if err != nil {
-		fmt.Printf("Failed to pull Git repository %s. Error: %s", path, err)
+		PrintErrorMsg(fmt.Sprintf("Failed to pull Git repository %s. Error: %s", path, err))
 	}
 	return output
 }
@@ -122,7 +121,7 @@ func PullGitRepo(path string) string {
 func StashGitRepo(path string, stashCmd string) string {
 	output, err := RunGitCmd(path, "stash", nil, []string{stashCmd}...)
 	if err != nil {
-		fmt.Printf("Failed to run stash with %s Git repository %s. Error: %s", stashCmd, path, err)
+		PrintErrorMsg(fmt.Sprintf("Failed to run stash with %s Git repository %s. Error: %s", stashCmd, path, err))
 	}
 	return output
 }
@@ -178,7 +177,7 @@ func GetGitLog(path string, oneline bool, numCommits int) string {
 
 	output, err := RunGitCmd(path, "log", nil, cmdArgs...)
 	if err != nil {
-		fmt.Printf("Failed to check Git log of %s. Error: %s", path, err)
+		PrintErrorMsg(fmt.Sprintf("Failed to check Git log of %s. Error: %s", path, err))
 	}
 	return output
 }
@@ -220,7 +219,7 @@ func GitClone(url string, version string, clonePath string, overwriteExisting bo
 		} else {
 			// Remove existing clonePath
 			if err := os.RemoveAll(clonePath); err != nil {
-				fmt.Printf("Failed to remove existing cloning path %s. Error: %s\n", clonePath, err)
+				PrintErrorMsg(fmt.Sprintf("Failed to remove existing cloning path %s. Error: %s\n", clonePath, err))
 				panic(err)
 			}
 		}

--- a/utils/print_helpers.go
+++ b/utils/print_helpers.go
@@ -12,7 +12,7 @@ const (
 )
 
 func PrintRepoEntry(path string, msg string) {
-	fmt.Printf("%s=== %s ===%s\n%s\n", BlueColor, path, ResetColor, msg)
+	fmt.Printf("%s=== %s ===%s\n%s", BlueColor, path, ResetColor, msg)
 }
 
 func PrintSection(msg string) {
@@ -20,6 +20,14 @@ func PrintSection(msg string) {
 }
 func PrintSeparator() {
 	fmt.Printf("%s--------------------%s\n", PurpleColor, ResetColor)
+}
+
+func PrintInfoMsg(msg string) {
+	fmt.Printf("%s%s%s", BlueColor, msg, ResetColor)
+}
+
+func PrintWarnMsg(msg string) {
+	fmt.Printf("%s%s%s", OrangeColor, msg, ResetColor)
 }
 
 func PrintErrorMsg(msg string) {

--- a/utils/repos_helpers.go
+++ b/utils/repos_helpers.go
@@ -30,7 +30,7 @@ type Config struct {
 	Repositories map[string]Repository `yaml:"repositories"`
 }
 
-func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (c *Config) UnmarshalYAML(unmarshal func(any) error) error {
 	// Try to unmarshal as .repos format
 	type configA Config
 	var a configA

--- a/utils/repos_helpers.go
+++ b/utils/repos_helpers.go
@@ -19,11 +19,13 @@ type Repository struct {
 	Type    string `yaml:"type"`
 	URL     string `yaml:"url"`
 	Version string `yaml:"version,omitempty"`
+	Exclude []string `yaml:"exclude,omitempty"`
 }
 type RepositoryRosinstall struct {
 	LocalName string `yaml:"local-name"`
 	URL       string `yaml:"uri"`
 	Version   string `yaml:"version,omitempty"`
+	Exclude []string `yaml:"exclude,omitempty"`
 }
 
 type Config struct {
@@ -50,6 +52,7 @@ func (c *Config) UnmarshalYAML(unmarshal func(any) error) error {
 					Type:    key,
 					URL:     repo.URL,
 					Version: repo.Version,
+					Exclude: repo.Exclude,
 				}
 			}
 		}


### PR DESCRIPTION
This addresses #21 

## Test Case

I tested this functionality with the following command

`go run main.go import -i ./test/nested_example.repos /tmp/example --recursive -x naoqi_libqicore`

This produces the following output 

```console
❯ go run main.go import -i ./test/nested_example.repos /tmp/example --recursive -x naoqi_libqicore
--------------------
Importing from ./test/nested_example.repos
--------------------
=== /tmp/example/twist_mux_2/stuff ===
Successfully cloned git repository 'https://github.com/ros-teleop/twist_mux.git' with version 'humble'
=== /tmp/example/twist_mux ===
Successfully cloned git repository 'https://github.com/ros-teleop/twist_mux.git' with version 'humble'
=== /tmp/example/naoqi_driver2 ===
Successfully cloned git repository 'https://github.com/ros-naoqi/naoqi_driver2' with version 'main'
--------------------
Importing from /tmp/example/naoqi_driver2/dependencies.repos
--------------------
=== /tmp/example/naoqi_bridge_msgs ===
Successfully cloned git repository 'https://github.com/ros-naoqi/naoqi_bridge_msgs2.git' with version 'ma
in'
=== /tmp/example/pepper_meshes ===
Successfully cloned git repository 'https://github.com/ros-naoqi/pepper_meshes2.git' with version 'main'
=== /tmp/example/nao_meshes ===
Successfully cloned git repository 'https://github.com/ros-naoqi/nao_meshes2.git' with version 'main'
=== /tmp/example/naoqi_libqicore ===
Successfully cloned git repository 'https://github.com/ros-naoqi/libqicore.git' with version 'ros2'
=== /tmp/example/naoqi_libqi ===
Successfully cloned git repository 'https://github.com/ros-naoqi/libqi.git' with version 'ros2'
--------------------
Excluded cloning from '/tmp/example/twist_mux/twist_mux_deps.repos'
--------------------
Excluded cloning from '/tmp/example/twist_mux_2/stuff/twist_mux_deps.repos'
--------------------
Excluded cloning from '/tmp/example/naoqi_libqicore/dependencies.repos'
```

and it would look like this in the file tree

```console
❯ ls /tmp/example --tree -L 2 --icons=never
/tmp/example
├── nao_meshes
│  ├── CHANGELOG.rst
...
├── naoqi_bridge_msgs
│  ├── action
...
├── naoqi_driver2
│  ├── app
...
├── naoqi_libqi
│  ├── AUTHORS
...
├── naoqi_libqicore
│  ├── CHANGELOG.rst
...
├── pepper_meshes
│  ├── CHANGELOG.rst
...
├── twist_mux
│  ├── CHANGELOG.rst
...
└── twist_mux_2
   └── stuff
      ├── CHANGELOG.rst
...
```