### PR TITLE
Add recurse-submodules option

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Flags:
   -f, --force                 Force overwriting existing repositories
   -h, --help                  help for import
   -i, --input .repos          Path to input .repos file
+  -s, --recurse-submodules    Recursively clone submodules
   -r, --recursive .repos      Recursively search of other .repos file in the cloned repositories
   -n, --retry int             Number of attempts to import repositories (default 2)
   -l, --shallow               Clone repositories with a depth of 1

--- a/test/git_helpers_test.go
+++ b/test/git_helpers_test.go
@@ -203,10 +203,10 @@ func TestCloneGitRepo(t *testing.T) {
 	if utils.GitClone("https://github.com/ros2/demos.git", "", repoPath, true, true, false, false) != utils.SuccessfullClone {
 		t.Errorf("Expected to successfully to clone git repository with shallow enabled")
 	}
-	if utils.GitCLone("https://github.com/cyberbotics/webots_ros2.git", "", repoPath, false, false, false, true) != utils.SuccessfullClone {
+	if utils.GitClone("https://github.com/cyberbotics/webots_ros2.git", "", repoPath, false, false, false, true) != utils.SuccessfullClone {
 		t.Errorf("Expected to successfully to clone git repository with submodules")
 	}
-	if utils.GitCLone("https://github.com/cyberbotics/webots_ros2.git", "", repoPath, false, true, false, true) != utils.SuccessfullClone {
+	if utils.GitClone("https://github.com/cyberbotics/webots_ros2.git", "", repoPath, false, true, false, true) != utils.SuccessfullClone {
 		t.Errorf("Expected to successfully to clone git repository with submodules and shallow enabled")
 	}
 	count, err := utils.RunGitCmd(repoPath, "rev-list", nil, []string{"--all", "--count"}...)

--- a/test/git_helpers_test.go
+++ b/test/git_helpers_test.go
@@ -203,6 +203,12 @@ func TestCloneGitRepo(t *testing.T) {
 	if utils.GitClone("https://github.com/ros2/demos.git", "", repoPath, true, true, false, false) != utils.SuccessfullClone {
 		t.Errorf("Expected to successfully to clone git repository with shallow enabled")
 	}
+	if utils.GitCLone("https://github.com/cyberbotics/webots_ros2.git", "", repoPath, false, false, false, true) != utils.SuccessfullClone {
+		t.Errorf("Expected to successfully to clone git repository with submodules")
+	}
+	if utils.GitCLone("https://github.com/cyberbotics/webots_ros2.git", "", repoPath, false, true, false, true) != utils.SuccessfullClone {
+		t.Errorf("Expected to successfully to clone git repository with submodules and shallow enabled")
+	}
 	count, err := utils.RunGitCmd(repoPath, "rev-list", nil, []string{"--all", "--count"}...)
 	if err != nil || strings.TrimSpace(count) != "1" {
 		t.Errorf("Expected to have a shallow clone of the git repository")

--- a/test/git_helpers_test.go
+++ b/test/git_helpers_test.go
@@ -85,14 +85,14 @@ func TestGitStatus(t *testing.T) {
 func TestGetGitBranch(t *testing.T) {
 	testingBranch := "jazzy"
 	repoPath := "/tmp/testdata/demos_branch"
-	if utils.GitClone("https://github.com/ros2/demos.git", testingBranch, repoPath, true, false, false) != utils.SuccessfullClone {
+	if utils.GitClone("https://github.com/ros2/demos.git", testingBranch, repoPath, true, false, false, false) != utils.SuccessfullClone {
 		t.Errorf("Expected to successfully clone git repository")
 	}
 	if utils.GetGitBranch(repoPath) != testingBranch {
 		t.Errorf("Failed to get main branch for valid git repository")
 	}
 	testingTag := "0.34.0"
-	if utils.GitClone("https://github.com/ros2/demos.git", testingTag, repoPath, true, false, false) != utils.SuccessfullClone {
+	if utils.GitClone("https://github.com/ros2/demos.git", testingTag, repoPath, true, false, false, false) != utils.SuccessfullClone {
 		t.Errorf("Expected to successfully clone git repository")
 	}
 	obtainedTag := utils.GetGitBranch(repoPath)
@@ -104,7 +104,7 @@ func TestGetGitBranch(t *testing.T) {
 func TestGetGitCommitSha(t *testing.T) {
 	testingSha := "839b622bc40ec62307d6ba0615adb9b8bd1cbc30"
 	repoPath := "/tmp/testdata/demos_sha"
-	if utils.GitClone("https://github.com/ros2/demos.git", testingSha, repoPath, false, false, false) != utils.SuccessfullClone {
+	if utils.GitClone("https://github.com/ros2/demos.git", testingSha, repoPath, false, false, false, false) != utils.SuccessfullClone {
 		t.Errorf("Expected to successfully clone git repository")
 	}
 	if utils.GetGitCommitSha(repoPath) != testingSha {
@@ -115,7 +115,7 @@ func TestGetGitCommitSha(t *testing.T) {
 func TestGetGitRemoteURL(t *testing.T) {
 	repoPath := "/tmp/testdata/demos_url"
 	remoteUrl := "https://github.com/ros2/demos.git"
-	if utils.GitClone(remoteUrl, "", repoPath, false, false, false) != utils.SuccessfullClone {
+	if utils.GitClone(remoteUrl, "", repoPath, false, false, false, false) != utils.SuccessfullClone {
 		t.Errorf("Expected to successfully clone git repository")
 	}
 	if utils.GetGitRemoteURL(repoPath) != remoteUrl {
@@ -125,7 +125,7 @@ func TestGetGitRemoteURL(t *testing.T) {
 
 func TestGitPull(t *testing.T) {
 	repoPath := "/tmp/testdata/demos_pull"
-	if utils.GitClone("https://github.com/ros2/demos.git", "rolling", repoPath, false, false, false) != utils.SuccessfullClone {
+	if utils.GitClone("https://github.com/ros2/demos.git", "rolling", repoPath, false, false, false, false) != utils.SuccessfullClone {
 		t.Errorf("Expected to successfully clone git repository")
 	}
 	msg := utils.PullGitRepo(repoPath)
@@ -185,22 +185,22 @@ func TestIsValidCommitSha(t *testing.T) {
 
 func TestCloneGitRepo(t *testing.T) {
 	repoPath := "/tmp/testdata/demos_clone"
-	if utils.GitClone("https://github.com/ros2/demos.git", "rolling", repoPath, false, false, false) != utils.SuccessfullClone {
+	if utils.GitClone("https://github.com/ros2/demos.git", "rolling", repoPath, false, false, false, false) != utils.SuccessfullClone {
 		t.Errorf("Expected to successfully clone git repository")
 	}
-	if utils.GitClone("https://github.com/ros2/ros2cli", "", "/tmp/testdata/ros2cli", false, false, false) != utils.SuccessfullClone {
+	if utils.GitClone("https://github.com/ros2/ros2cli", "", "/tmp/testdata/ros2cli", false, false, false, false) != utils.SuccessfullClone {
 		t.Errorf("Expected to successfully clone git repository")
 	}
-	if utils.GitClone("https://github.com/ros2/sadasdasd.git", "", "/tmp/testdata/sdasda", false, false, false) != utils.FailedClone {
+	if utils.GitClone("https://github.com/ros2/sadasdasd.git", "", "/tmp/testdata/sdasda", false, false, false, false) != utils.FailedClone {
 		t.Errorf("Expected to fail to clone git repository")
 	}
-	if utils.GitClone("https://github.com/ros2/demos.git", "", repoPath, false, false, false) != utils.SkippedClone {
+	if utils.GitClone("https://github.com/ros2/demos.git", "", repoPath, false, false, false, false) != utils.SkippedClone {
 		t.Errorf("Expected to skip to clone git repository")
 	}
-	if utils.GitClone("https://github.com/ros2/demos.git", "", repoPath, true, false, false) != utils.SuccessfullClone {
+	if utils.GitClone("https://github.com/ros2/demos.git", "", repoPath, true, false, false, false) != utils.SuccessfullClone {
 		t.Errorf("Expected to overwrite found git repository")
 	}
-	if utils.GitClone("https://github.com/ros2/demos.git", "", repoPath, true, true, false) != utils.SuccessfullClone {
+	if utils.GitClone("https://github.com/ros2/demos.git", "", repoPath, true, true, false, false) != utils.SuccessfullClone {
 		t.Errorf("Expected to successfully to clone git repository with shallow enabled")
 	}
 	count, err := utils.RunGitCmd(repoPath, "rev-list", nil, []string{"--all", "--count"}...)
@@ -209,14 +209,14 @@ func TestCloneGitRepo(t *testing.T) {
 	}
 
 	testingSha := "839b622bc40ec62307d6ba0615adb9b8bd1cbc30"
-	if utils.GitClone("https://github.com/ros2/demos.git", testingSha, repoPath, true, false, false) != utils.SuccessfullClone {
+	if utils.GitClone("https://github.com/ros2/demos.git", testingSha, repoPath, true, false, false, false) != utils.SuccessfullClone {
 		t.Errorf("Expected to successfully clone git repository given a SHA")
 	}
 }
 
 func TestGitSwitch(t *testing.T) {
 	repoPath := "/tmp/testdata/switch_test"
-	if utils.GitClone("https://github.com/ros2/demos.git", "rolling", repoPath, false, false, false) != utils.SuccessfullClone {
+	if utils.GitClone("https://github.com/ros2/demos.git", "rolling", repoPath, false, false, false, false) != utils.SuccessfullClone {
 		t.Errorf("Expected to successfully clone git repository")
 	}
 	_, err := utils.GitSwitch(repoPath, "humble", false, false)

--- a/test/git_helpers_test.go
+++ b/test/git_helpers_test.go
@@ -203,10 +203,10 @@ func TestCloneGitRepo(t *testing.T) {
 	if utils.GitClone("https://github.com/ros2/demos.git", "", repoPath, true, true, false, false) != utils.SuccessfullClone {
 		t.Errorf("Expected to successfully to clone git repository with shallow enabled")
 	}
-	if utils.GitClone("https://github.com/cyberbotics/webots_ros2.git", "", repoPath, false, false, false, true) != utils.SuccessfullClone {
+	if utils.GitClone("https://github.com/cyberbotics/webots_ros2.git", "", "/tmp/testdata/webots_ros2", false, false, false, true) != utils.SuccessfullClone {
 		t.Errorf("Expected to successfully to clone git repository with submodules")
 	}
-	if utils.GitClone("https://github.com/cyberbotics/webots_ros2.git", "", repoPath, false, true, false, true) != utils.SuccessfullClone {
+	if utils.GitClone("https://github.com/cyberbotics/webots_ros2.git", "", "/tmp/testdata/webots_ros2", true, true, false, true) != utils.SuccessfullClone {
 		t.Errorf("Expected to successfully to clone git repository with submodules and shallow enabled")
 	}
 	count, err := utils.RunGitCmd(repoPath, "rev-list", nil, []string{"--all", "--count"}...)

--- a/test/repos_helpers_test.go
+++ b/test/repos_helpers_test.go
@@ -139,7 +139,7 @@ func TestParseRepositoryInfo(t *testing.T) {
 	repoPath := "/tmp/testdata/demos_parse"
 	repoURL := "https://github.com/ros2/demos.git"
 	repoVersion := "rolling"
-	if utils.GitClone(repoURL, repoVersion, repoPath, true, false, false) != utils.SuccessfullClone {
+	if utils.GitClone(repoURL, repoVersion, repoPath, true, false, false, false) != utils.SuccessfullClone {
 		t.Errorf("Expected to successfully clone git repository")
 	}
 
@@ -149,7 +149,7 @@ func TestParseRepositoryInfo(t *testing.T) {
 	}
 
 	repoVersion = "839b622bc40ec62307d6ba0615adb9b8bd1cbc30"
-	if utils.GitClone(repoURL, repoVersion, repoPath, true, false, false) != utils.SuccessfullClone {
+	if utils.GitClone(repoURL, repoVersion, repoPath, true, false, false, false) != utils.SuccessfullClone {
 		t.Errorf("Expected to successfully clone git repository")
 	}
 	repository = utils.ParseRepositoryInfo(repoPath, true)
@@ -158,7 +158,7 @@ func TestParseRepositoryInfo(t *testing.T) {
 	}
 
 	repoVersion = "0.34.0"
-	if utils.GitClone(repoURL, repoVersion, repoPath, true, false, false) != utils.SuccessfullClone {
+	if utils.GitClone(repoURL, repoVersion, repoPath, true, false, false, false) != utils.SuccessfullClone {
 		t.Errorf("Expected to successfully clone git repository")
 	}
 	repository = utils.ParseRepositoryInfo(repoPath, false)

--- a/utils/git_helpers.go
+++ b/utils/git_helpers.go
@@ -210,7 +210,7 @@ func IsValidSha(sha string) bool {
 }
 
 // GitClone Clone a given repository URL
-func GitClone(url string, version string, clonePath string, overwriteExisting bool, shallowClone bool, enablePrompt bool) int {
+func GitClone(url string, version string, clonePath string, overwriteExisting bool, shallowClone bool, enablePrompt bool, recurseSubmodules bool) int {
 
 	// Check if clonePath exists
 	if _, err := os.Stat(clonePath); err == nil {
@@ -243,6 +243,12 @@ func GitClone(url string, version string, clonePath string, overwriteExisting bo
 
 	if shallowClone {
 		cmdArgs = append(cmdArgs, "--depth", "1")
+	}
+	if recurseSubmodules {
+		cmdArgs = append(cmdArgs, "--recurse-submodules")
+		if shallowClone {
+			cmdArgs = append(cmdArgs, "--shallow-submodules")
+		}
 	}
 	if _, err := RunGitCmd(".", "clone", envConfig, cmdArgs...); err != nil {
 		return FailedClone
@@ -308,10 +314,10 @@ func PrintCheckGit(path string, url string, version string, enablePrompt bool) b
 }
 
 // PrintGitClone Pretty print git clone
-func PrintGitClone(url string, version string, path string, overwriteExisting bool, shallowClone bool, enablePrompt bool) bool {
+func PrintGitClone(url string, version string, path string, overwriteExisting bool, shallowClone bool, enablePrompt bool, recurseSubmodules bool) bool {
 	var cloneMsg string
 	var cloneSuccessful bool
-	statusClone := GitClone(url, version, path, overwriteExisting, shallowClone, enablePrompt)
+	statusClone := GitClone(url, version, path, overwriteExisting, shallowClone, enablePrompt, recurseSubmodules)
 	switch statusClone {
 	case SuccessfullClone:
 		cloneMsg = fmt.Sprintf("Successfully cloned git repository '%s' with version '%s'\n", url, version)


### PR DESCRIPTION
I added the `recurse-submodules` option to automatically set up submodules when cloning.

- fix #24 

I tested this behavior using the following `.repos` file.

```yaml
repositories:
  xarm_ros2:
    type: git
    url: https://github.com/xArm-Developer/xarm_ros2.git
    version: jazzy
```

`rv import -i test.repos /tmp/example -r -s`

with shallow option
`rv import -i test.repos /tmp/example -r -s -l`

