### PR TITLE
Resolve exclude correctly

### DIFF
--- a/test/git_helpers_test.go
+++ b/test/git_helpers_test.go
@@ -194,11 +194,14 @@ func TestCloneGitRepo(t *testing.T) {
 	if utils.GitClone("https://github.com/ros2/sadasdasd.git", "", "/tmp/testdata/sdasda", false, false, false, false) != utils.FailedClone {
 		t.Errorf("Expected to fail to clone git repository")
 	}
-	if utils.GitClone("https://github.com/ros2/demos.git", "", repoPath, false, false, false, false) != utils.SkippedClone {
+	if utils.GitClone("https://github.com/ros2/demos.git", "rolling", repoPath, false, false, false, false) != utils.SkippedClone {
 		t.Errorf("Expected to skip to clone git repository")
 	}
 	if utils.GitClone("https://github.com/ros2/demos.git", "", repoPath, true, false, false, false) != utils.SuccessfullClone {
 		t.Errorf("Expected to overwrite found git repository")
+	}
+	if utils.GitClone("https://github.com/ros2/demos.git", "jazzy", repoPath, false, false, false, false) != utils.SwitchedBranch {
+		t.Errorf("Expected to successfully to switch to a branch")
 	}
 	if utils.GitClone("https://github.com/ros2/demos.git", "", repoPath, true, true, false, false) != utils.SuccessfullClone {
 		t.Errorf("Expected to successfully to clone git repository with shallow enabled")

--- a/test/repos_helpers_test.go
+++ b/test/repos_helpers_test.go
@@ -81,15 +81,20 @@ func TestParsingReposFile(t *testing.T) {
 }
 
 func TestFindingReposFiles(t *testing.T) {
-	foundReposFiles, err := utils.FindReposFiles(".")
+	foundReposFiles, err := utils.FindReposFiles(".", nil)
 
 	if err != nil || len(foundReposFiles) == 0 {
 		t.Errorf("Expected to find at least one .repos file %v", err)
 	}
-	foundReposFiles, err = utils.FindReposFiles("../cmd/")
+	foundReposFiles, err = utils.FindReposFiles("../cmd/", nil)
 
 	if err != nil || len(foundReposFiles) != 0 {
 		t.Errorf("Expected to not find any .repos file %v", err)
+	}
+
+	foundReposFiles, err = utils.FindReposFiles(".", []string{"../test"})
+	if err != nil || len(foundReposFiles) == 0 {
+		t.Errorf("Expected to find at least one .repos file %v", err)
 	}
 }
 

--- a/utils/repos_helpers.go
+++ b/utils/repos_helpers.go
@@ -110,31 +110,30 @@ func ParseReposFile(filePath string) (*Config, error) {
 // FindReposFiles Search .repos files in a given path
 func FindReposFiles(rootPath string, clonedPaths []string) ([]string, error) {
 	var foundReposFiles []string
-	err := filepath.Walk(rootPath, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		// If clonedPaths is not empty, only consider files under those directories
-		if len(clonedPaths) > 0 {
-			matched := false
-			for _, clonedPath := range clonedPaths {
-				absClonedPath, _ := filepath.Abs(clonedPath)
-				absPath, _ := filepath.Abs(path)
-				rel, relErr := filepath.Rel(absClonedPath, absPath)
-				if relErr == nil && (rel == "." || !strings.HasPrefix(rel, "..")) {
-					matched = true
-					break
+	var err error
+	if len(clonedPaths) == 0 {
+		err = filepath.Walk(rootPath, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if !info.IsDir() && (filepath.Ext(path) == ".repos") {
+				foundReposFiles = append(foundReposFiles, path)
+			}
+			return nil
+		})
+	} else {
+		for _, clonedPath := range clonedPaths {
+			err = filepath.Walk(clonedPath, func(path string, info os.FileInfo, err error) error {
+				if err != nil {
+					return err
 				}
-			}
-			if !matched {
+				if !info.IsDir() && (filepath.Ext(path) == ".repos") {
+					foundReposFiles = append(foundReposFiles, path)
+				}
 				return nil
-			}
+			})
 		}
-		if !info.IsDir() && (filepath.Ext(path) == ".repos") {
-			foundReposFiles = append(foundReposFiles, path)
-		}
-		return nil
-	})
+	}
 
 	return foundReposFiles, err
 }


### PR DESCRIPTION
I resolved an issue where, in an already constructed environment, repositories were cloned before being excluded due to the order in which they were discovered.
From now on, only the directories listed in the initially specified .repos file will be recursively searched.
In other words, even if there are other .repos files or manually cloned repositories in the workspace, those .repos files will no longer be part of the search targets.
I believe this behavior is correct for an “import based on the initially specified .repos file.”

Separately, there may be value in having a feature that imports all .repos files discovered across the entire workspace, without an initially specified .repos file.
However, I consider that to be a different issue.

Additionally, during testing, I noticed that attempting to change only the version of an already cloned repository resulted in “Skipped cloning,” and the version remained unchanged.
To address this, I made it so that even if the repository is already cloned, it will be switched if the version differs. https://github.com/ErickKramer/ripvcs/commit/f241ad4b278dfb1a57cb2a2d3235c73673bb2f41

- fix #23 

test behavior

nested_example2.repos
```yaml
repositories:
  ripvcs:
    type: git
    url: https://github.com/Tacha-S/ripvcs.git
    version: test/nested_exclude
    exclude:
      - invalid_example.repos
      - valid_example.repos
      - valid_example.rosinstall
```

`go run main.go import -i ./test/nested_example2.repos /tmp/example --recursive -x naoqi_libqicore`