### PR TITLE
fix: Ensure ripvcs is not bound to a specific libc version

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install dependencies
         run: go get .
       - name: Build
-        run: go build -v ./...
+        run: CGO_ENABLED=0 go build -v ./...
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,3 +112,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GH_API_TOKEN }}
+          CGO_ENABLED: 0

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -12,9 +12,9 @@ import (
 
 var (
 	// These variables should be set using ldflags during the build
-	Version   = "v1.0.2"
-	Commit    = "071f3a7"
-	BuildDate = "22.05.2025"
+	Version   = "v1.0.3"
+	Commit    = "f0eae29"
+	BuildDate = "24.06.2025"
 )
 
 // versionCmd represents the version command


### PR DESCRIPTION
Without this change, ripvcs cannot be used in old linux operating systems.